### PR TITLE
Fix forecast date display

### DIFF
--- a/project/script.js
+++ b/project/script.js
@@ -152,15 +152,24 @@ class PersonalDashboard {
         // Update local time display
         const timeElement = document.getElementById('time-value');
         if (timeElement) {
-            const now = new Date();
-            const timeString = now.toLocaleString('en-US', {
-                timeZone: 'America/Los_Angeles',
-                hour: 'numeric',
-                minute: '2-digit',
-                hour12: true,
-                weekday: 'long'
-            });
-            timeElement.textContent = timeString;
+            // Use a function to get the most current time when the element is updated
+            const updateTime = () => {
+                const now = new Date();
+                const timeString = now.toLocaleString('en-US', {
+                    timeZone: 'America/Los_Angeles',
+                    hour: 'numeric',
+                    minute: '2-digit',
+                    hour12: true,
+                    weekday: 'long'
+                });
+                timeElement.textContent = timeString;
+            };
+            
+            // Update immediately
+            updateTime();
+            
+            // Update every 30 seconds to keep time current
+            setInterval(updateTime, 30000);
         }
     }
     
@@ -215,8 +224,8 @@ class PersonalDashboard {
                 <div class="forecast-date">${dayName}<br><span style="font-size: 0.8em; opacity: 0.9; color: var(--text-muted);">${monthDay}</span></div>
                 <div class="forecast-icon">${weatherInfo.icon}</div>
                 <div class="forecast-temps">
-                    <span class="forecast-high">${maxTemp}°</span>
-                    <span class="forecast-low">${minTemp}°</span>
+                    <span class="forecast-high">High ${maxTemp}°</span>
+                    <span class="forecast-low">Low ${minTemp}°</span>
                 </div>
                 <div class="forecast-desc">${weatherInfo.description}</div>
                 <div class="forecast-details">

--- a/project/script.js
+++ b/project/script.js
@@ -183,8 +183,21 @@ class PersonalDashboard {
         
         // Create forecast cards for each day
         for (let i = 0; i < Math.min(7, forecastData.daily.time.length); i++) {
-            const date = new Date(forecastData.daily.time[i]);
-            const dayName = i === 0 ? 'Today' : date.toLocaleDateString('en-US', { weekday: 'short' });
+            // Parse the date string from the API (YYYY-MM-DD format)
+            const dateString = forecastData.daily.time[i];
+            const date = new Date(dateString + 'T12:00:00'); // Add noon time to avoid timezone issues
+            
+            // Get today's date in Los Angeles timezone
+            const today = new Date();
+            const todayLA = new Date(today.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }));
+            const todayDateString = todayLA.getFullYear() + '-' + 
+                                    String(todayLA.getMonth() + 1).padStart(2, '0') + '-' + 
+                                    String(todayLA.getDate()).padStart(2, '0');
+            
+            // Check if this forecast date is today by comparing date strings
+            const isToday = dateString === todayDateString;
+            
+            const dayName = isToday ? 'Today' : date.toLocaleDateString('en-US', { weekday: 'short' });
             const monthDay = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
             
             const maxTemp = Math.round(forecastData.daily.temperature_2m_max[i]);


### PR DESCRIPTION
Correctly identifies 'Today' in the 7-day forecast by comparing dates in the Los Angeles timezone.

The previous implementation incorrectly labeled the first forecast day as "Today" without comparing it to the actual current date in the correct timezone, leading to "Today" showing yesterday's date. The fix now explicitly compares the forecast date with the current date in the Los Angeles timezone to accurately determine which day is "Today."

---

[Open in Web](https://cursor.com/agents?id=bc-eec279a5-6698-44b7-b2d7-07024133431b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-eec279a5-6698-44b7-b2d7-07024133431b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)